### PR TITLE
Multilocalization

### DIFF
--- a/include/odom_tf.hpp
+++ b/include/odom_tf.hpp
@@ -9,7 +9,7 @@ class odomTF {
     
 public:
     ~odomTF() = default;
-    odomTF(ros::NodeHandle& nh);
+    odomTF(ros::NodeHandle& nh, const std::string robot_id);
 
     void transformCallback(const nav_msgs::Odometry& odom);
 
@@ -17,6 +17,7 @@ private:
     ros::NodeHandle nh_;
     ros::Subscriber sub;
     tf::TransformBroadcaster odom_broadcaster;
+    const std::string robot_id_;
 };
 
 #endif

--- a/src/odom_tf.cpp
+++ b/src/odom_tf.cpp
@@ -1,8 +1,10 @@
 #include "odom_tf.hpp"
 
-odomTF::odomTF(ros::NodeHandle& nh) {
+odomTF::odomTF(ros::NodeHandle& nh, const std::string robot_id): robot_id_(robot_id) {
     nh_ = nh;
-    sub = nh_.subscribe("odom_data_euler", 1000, &odomTF::transformCallback, this);  
+    sub = nh_.subscribe("odom_data_euler", 1000, &odomTF::transformCallback, this);
+    // Set prefix to make tf agent specific
+    nh_.setParam("tf_prefix", robot_id_.c_str());
 }
 
 void odomTF::transformCallback(const nav_msgs::Odometry& odom) {

--- a/src/odom_tf.cpp
+++ b/src/odom_tf.cpp
@@ -3,15 +3,13 @@
 odomTF::odomTF(ros::NodeHandle& nh, const std::string robot_id): robot_id_(robot_id) {
     nh_ = nh;
     sub = nh_.subscribe("odom_data_euler", 1000, &odomTF::transformCallback, this);
-    // Set prefix to make tf agent specific
-    nh_.setParam("tf_prefix", robot_id_.c_str());
 }
 
 void odomTF::transformCallback(const nav_msgs::Odometry& odom) {
     geometry_msgs::TransformStamped odom_trans;
     odom_trans.header.stamp = odom.header.stamp;
-    odom_trans.header.frame_id = "odom";
-    odom_trans.child_frame_id = "base_link";
+    odom_trans.header.frame_id = robot_id_ + "/odom";
+    odom_trans.child_frame_id = robot_id_ + "/base_link";
 
     // translation
     odom_trans.transform.translation.x = odom.pose.pose.position.x;


### PR DESCRIPTION
Modified code to support multi-robot localization; now published transforms are robot specific. eg. odom->base_link has been changed to agent1/odom->agent1/base_link. Depends on multilocalization changes in robosar_agent_bringup, and impacts robosar_slam_toolbox